### PR TITLE
Fix upper tail sign in normSInv

### DIFF
--- a/gemini.html
+++ b/gemini.html
@@ -374,7 +374,7 @@
       q = Math.sqrt(-2 * Math.log(1 - p));
       x = ((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6;
       x = x / ((((d1 * q + d2) * q + d3) * q + d4) * q + 1);
-      return x;
+      return -x; // Corrige sinal para região de cauda superior
     }
 
     function calculaTamanhoAmostra(p1, p2, alpha, power) {

--- a/gpt.html
+++ b/gpt.html
@@ -299,7 +299,7 @@
       q = Math.sqrt(-2 * Math.log(1 - p));
       x = ((((c1 * q + c2) * q + c3) * q + c4) * q + c5) * q + c6;
       x = x / ((((d1 * q + d2) * q + d3) * q + d4) * q + 1);
-      return x;
+      return -x; // Corrige sinal para região de cauda superior
     }
 
     function calculaTamanhoAmostra(p1, p2, alpha, power) {


### PR DESCRIPTION
## Summary
- return negative value for `normSInv` when `p` is in the upper tail

This fixes incorrect visitor calculation because the previous sign was wrong.

## Testing
- `ping -c 1 google.com` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6840ab6737a0832ca2f517f388b2961a